### PR TITLE
Add to_fingerprint_md5_string to get MD5 fingerprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ base64 = "0.6"
 byteorder = "1.1"
 error-chain = { version = "0.11", default-features = false }
 sha2 = "0.6"
-rust-crypto = "0.2.36"
+rust-crypto = "0.2.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ base64 = "0.6"
 byteorder = "1.1"
 error-chain = { version = "0.11", default-features = false }
 sha2 = "0.6"
+rust-crypto = "0.2.36"


### PR DESCRIPTION
Signed-off-by: Eli Ma <eli@patch.sh>
---
In some scenarios use the _*old*_ MD5 fingerprint to manipulate the SSH public key, so I add the `to_fingerprint_md5_string` to get.

To get _*MD5*_ fingerprint with command `ssh-keygen -l -E md5 -f key`.

Scenarios examples:
* destroy an SSH key in [Digitalocean API](https://developers.digitalocean.com/documentation/v2/#destroy-a-key)

Also, I added a test case and passed:

```
test tests::rsa_fingerprint_md5_string ... ok
```


