### PR TITLE
publickey: fix clippy warning in parse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ impl PublicKey {
                     }
                 }
             }
-            let mut parsed = PublicKey::try_key_parse(&key[key_start..]).or(Err(e))?;
+            let mut parsed = PublicKey::try_key_parse(&key[key_start..]).or_else(|_| Err(e))?;
             parsed.options = Some(key[..key_start-1].into());
             Ok(parsed)
         })


### PR DESCRIPTION
This fixes an `or_fun_call` warning spotted by clippy. Reference at
https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#or_fun_call