### PR TITLE
cargo: update error-chain to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ travis-ci = { repository = "sdemos/openssh-keys" }
 [dependencies]
 base64 = "0.8"
 byteorder = "1.1"
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 sha2 = "0.7"
 md-5 = "0.7"


### PR DESCRIPTION
Note: this is a breaking change as it affects public traits.