### PR TITLE
*: move repo under the coreos org on github

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.3.0"
 authors = ["Stephen Demos <stephen@demos.zone>"]
 description = "read and write OpenSSH public keys"
 documentation = "https://docs.rs/openssh-keys"
-homepage = "https://github.com/sdemos/openssh-keys"
-repository = "https://github.com/sdemos/openssh-keys"
+homepage = "https://github.com/coreos/openssh-keys"
+repository = "https://github.com/coreos/openssh-keys"
 readme = "README.md"
 keywords = ["ssh", "ssh-keys", "keys", "rsa", "openssh"]
 license = "MIT OR Apache-2.0"
 exclude = ["fixtures/*", "ci/*", "appveyor.yml", ".travis.yml", "examples/*"]
 
 [badges]
-appveyor = { repository = "sdemos/openssh-keys" }
-travis-ci = { repository = "sdemos/openssh-keys" }
+appveyor = { repository = "coreos/openssh-keys" }
+travis-ci = { repository = "coreos/openssh-keys" }
 
 [dependencies]
 base64 = "0.9"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # openssh-keys &emsp; [![Travis Status]][travis] [![AppVeyor Status]][appveyor] [![Latest Version]][crates.io] [![Docs Badge]][docs]
 
-[Travis Status]: https://api.travis-ci.org/sdemos/openssh-keys.svg?branch=master
-[travis]: https://travis-ci.org/sdemos/openssh-keys
+[Travis Status]: https://api.travis-ci.org/coreos/openssh-keys.svg?branch=master
+[travis]: https://travis-ci.org/coreos/openssh-keys
 [AppVeyor Status]: https://ci.appveyor.com/api/projects/status/kplw02ut4h9rbros?svg=true
-[appveyor]: https://ci.appveyor.com/project/sdemos/openssh-keys
+[appveyor]: https://ci.appveyor.com/project/coreos/openssh-keys
 [Latest Version]: https://img.shields.io/crates/v/openssh-keys.svg
 [crates.io]: https://crates.io/crates/openssh-keys
 [Docs Badge]: https://docs.rs/openssh-keys/badge.svg


### PR DESCRIPTION
this will ensure it continues to be maintained, since the primary
use-case that I know of is for github.com/coreos/coreos-metadata and
github.com/coreos/update-ssh-keys.

/cc: @lucab 